### PR TITLE
Build .deb files with sbuild

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,12 @@ jobs:
 
   release-linux:
     name: Build the Linux release artifact
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, linux, x64 ]
 
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.14.x
-
-      - name: Install Apt deps
-        run: sudo apt install dh-golang golang-any debhelper-compat
+      # Trust that the runner has an sbuild chroot
+      - name: Remove old release artifacts
+        run: rm -f ../kel-agent_*
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -42,7 +38,7 @@ jobs:
     runs-on: [ self-hosted, linux, ARM ]
 
     steps:
-      # Trust that the runner has a good golang version and apt deps
+      # Trust that the runner has an sbuild chroot
       - name: Remove old release artifacts
         run: rm -f ../kel-agent_*
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ kel-agent_mac.pkg
 win/kel-agent.msi
 win/kel-agent.wixobj
 win/kel-agent.wixpdb
+autorevision.cache
 
 .idea/
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
-all: kel-agent
+VERSION = $(shell < debian/changelog head -1 | egrep -o "[0-9]+\.[0-9]+\.[0-9]+")
+GITCOMMIT = $(shell git rev-parse --short HEAD 2> /dev/null || true)
+
+GENERATED = kel-agent kel-agent_*.pkg win/kel-agent_*.msi win/kel-agent.wixobj autorevision.cache ../kel-agent_*
+
 .PHONY: all
+all: kel-agent
 
 .PHONY: test
 test:
@@ -7,16 +12,23 @@ test:
 	go vet ./...
 
 kel-agent: test
-	scripts/build.sh
+	export GITCOMMIT=$(GITCOMMIT) && scripts/build.sh
 
 architecture.svg:
 	# apt install graphviz
 	dot -T svg -o architecture.svg < architecture.dot
 
+autorevision.cache:
+	autorevision -s VCS_SHORT_HASH -o ./autorevision.cache
+
+.PHONY: deb-tarball
+deb-tarball: autorevision.cache
+	cd .. && tar -cvzf kel-agent_$(VERSION).orig.tar.gz kel-agent
+
 .PHONY: deb-package
-deb-package:
-	# apt install build-essential devscripts
-	dpkg-buildpackage -uc -us -b
+deb-package: deb-tarball
+	# https://wiki.debian.org/sbuild
+	sbuild
 
 .PHONY: mac-package
 mac-package: kel-agent
@@ -31,4 +43,4 @@ win-package: kel-agent
 
 .PHONY: clean
 clean:
-	rm -f kel-agent kel-agent_mac.pkg
+	rm -f $(GENERATED)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ deb-tarball: autorevision.cache
 .PHONY: deb-package
 deb-package: deb-tarball
 	# https://wiki.debian.org/sbuild
-	sbuild
+	sbuild -d stable
 
 .PHONY: mac-package
 mac-package: kel-agent

--- a/VERSION.go
+++ b/VERSION.go
@@ -1,6 +1,6 @@
 package main
 
-// These are filled by `make` via `go build -ldflags`
+// These are filled by `go build --ldflags`
 var (
 	Version   = "unknown"
 	GitCommit = "unknown"

--- a/debian/control
+++ b/debian/control
@@ -8,8 +8,9 @@ Build-Depends: autorevision,
                ca-certificates,
                debhelper-compat (= 11),
                dh-golang,
+               git,
                golang-any
-Standards-Version: 4.5.0
+Standards-Version: 4.3.0
 Vcs-Browser: https://salsa.debian.org/go-team/packages/kel-agent
 Vcs-Git: https://salsa.debian.org/go-team/packages/kel-agent.git
 Homepage: https://github.com/k0swe/kel-agent

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,9 @@ Uploaders: Chris Keller <xylo04@gmail.com>
 Section: hamradio
 Testsuite: autopkgtest-pkg-go
 Priority: optional
-Build-Depends: debhelper-compat (= 11),
+Build-Depends: autorevision,
+               ca-certificates,
+               debhelper-compat (= 11),
                dh-golang,
                golang-any
 Standards-Version: 4.5.0

--- a/debian/rules
+++ b/debian/rules
@@ -3,6 +3,8 @@
 # build with `dpkg-buildpackage -uc -us -b`
 
 PKGDIR=debian/kel-agent
+HOME=$(CURDIR)
+GITCOMMIT = $(shell autorevision -f -o autorevision.cache -s VCS_SHORT_HASH)
 
 %:
 	dh $@
@@ -12,7 +14,7 @@ clean:
 	rm -rf $(PKGDIR)
 
 build:
-	make kel-agent
+	export GITCOMMIT=$(GITCOMMIT) && scripts/build.sh
 
 binary: clean build
 	dh_prep

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,7 +2,6 @@
 set -eu
 
 VERSION=${VERSION:-v$(< debian/changelog head -1 | egrep -o "[0-9]+\.[0-9]+\.[0-9]+")}
-GITCOMMIT=${GITCOMMIT:-$(git rev-parse --short HEAD 2> /dev/null || true)}
 BUILDTIME=${BUILDTIME:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}
 
 export LDFLAGS="\


### PR DESCRIPTION
Build the .deb release files for Linux x64 and ARM in `sbuild chroot`s. This will be more isolated and reproducible than using the Github-hosted Linux machine or the raw Raspberry Pi, and aligns better with the Debian official release process.

In particular, Debian builds are not supposed to assume that the VCS artifacts (i.e. the `.git` folder) is going to be there, so the new build system uses `autorevision` to store the VCS details.