### PR TITLE
make a "pure" orig.tar.xz for Debian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ autorevision.cache:
 
 .PHONY: deb-tarball
 deb-tarball: autorevision.cache
-	cd .. && tar -cvzf kel-agent_$(VERSION).orig.tar.gz kel-agent
+	cd .. && tar -cvJf kel-agent_$(VERSION).orig.tar.xz --exclude-vcs --exclude=debian --exclude=.github kel-agent
 
 .PHONY: deb-package
 deb-package: deb-tarball


### PR DESCRIPTION
Hi @xylo04 - this isn't really a pull-request as much as an easy way to demonstrate how I ended up generating kel-agent_0.2.2.orig.tar.xz for the Debian packaging.